### PR TITLE
Update org.springframework.boot:spring-boot-starter-web to 3.0.0 in java backend for security purposes

### DIFF
--- a/Backend-Java/pom.xml
+++ b/Backend-Java/pom.xml
@@ -46,6 +46,7 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
+			<version>3.0.0</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
To resolve this: https://snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORK-3369852
Need to update org.springframework:spring-webmvc to version 5.3.26, 6.0.7 or higher.
According to our security tooling, updating org.springframework.boot:spring-boot-starter-web to 3.0.0 will resolve this.

Locally built the backend and tested with `localhost:3000/api/me` call in local browser (following readme directions)

